### PR TITLE
Upgrading IntelliJ from 2025.2.4 to 2025.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.2.4 to 2025.2.5
 - Upgrading IntelliJ from 2025.2.3 to 2025.2.4
 
 ### Deprecated

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/rust-analyzer-lsp-intellij-
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 0.1.4
+pluginVersion = 0.1.5
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 252.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.2.5,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IU
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.2.4
+platformVersion = 2025.2.5
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.2.4 to 2025.2.5

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662535/IntelliJ-IDEA-2025.2.5-252.28238.7-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.2.5 is out with the following improvements:</p>
<ul>
 <li>The IDE now correctly processes API calls when the Docker Engine is updated to v29. [<a href="https://youtrack.jetbrains.com/issue/IJPL-217878">IJPL-217878</a>]</li>
 <li>Gradle 9.x projects with a Spring Boot now run as expected using the Gradle Runner. [<a href="https://youtrack.jetbrains.com/issue/IDEA-379009">IDEA-379009</a>]</li>
 <li>Resolved an issue where the IDE could hang when scanning HTTP request files containing certain JSON structures. [<a href="https://youtrack.jetbrains.com/issue/IJPL-212853">IJPL-212853</a>]</li>
 <li>The GitLab plugin now correctly handles large pipeline IDs. [<a href="https://youtrack.jetbrains.com/issue/IJPL-217571">IJPL-217571</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2025/11/intellij-idea-2025-2-5/">blog post</a>.</p>
    