### PR TITLE
Upgrading IntelliJ from 2025.3 to 2025.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.3 to 2025.3.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/rust-analyzer-lsp-intellij-
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 0.2.0
+pluginVersion = 0.2.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 253.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.3.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -31,7 +31,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.3
+platformVersion = 2025.3.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.3 to 2025.3.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662566/IntelliJ-IDEA-2025.3.1-253.29346.138-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.3.1 is out with the following improvements:</p>
<ul>
 <li>The IDE once again shows the <em>Resume Build From</em> button in the <em>Run</em> tool window for Maven projects. [<a href="https://youtrack.jetbrains.com/issue/IDEA-376908/">IDEA-376908</a>]</li>
 <li>In the<em> Version Control </em>section of <em>Advanced Settings</em>, there's now an option to disable the warning dialog on force-pushing. [<a href="https://youtrack.jetbrains.com/issue/IDEA-285542/">IDEA-285542</a>]</li>
 <li>Query result tabs now follow the corresponding active editor tabs as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-222217/">IJPL-222217</a>]</li>
 <li>Several issues that appeared when running or debugging in WSL using Gradle have been resolved. [<a href="https://youtrack.jetbrains.com/issue/IDEA-357963/">IDEA-357963</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-285542/">IDEA-285542</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-363930/">IDEA-363930</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-352779/">IDEA-352779</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2025/12/intellij-idea-2025-3-1/">blog post</a>.</p>
    