### PR TITLE
Upgrading IntelliJ from 2025.3.2 to 2025.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.3.2 to 2025.3.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/rust-analyzer-lsp-intellij-
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 0.2.3
+pluginVersion = 0.2.4
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 253.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.3.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.3.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -31,7 +31,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.3.2
+platformVersion = 2025.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.3.2 to 2025.3.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662633/IntelliJ-IDEA-2025.3.3-253.31033.145-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.3.3 is out with the following improvements:</p>
<ul>
 <li>MCP server output schema now correctly handles default properties in the schema, preventing invalid schema errors during structured output. [<a href="https://youtrack.jetbrains.com/issue/IJPL-230494">IJPL-230494</a>]</li>
 <li>Downloading the IDE backend now works as intended with a configured proxy. [<a href="https://youtrack.jetbrains.com/issue/IJPL-164318">IJPL-164318</a>]</li>
 <li>Resolved an issue that prevented successful proxy authentication. [<a href="https://youtrack.jetbrains.com/issue/IJPL-231829">IJPL-231829</a>]</li>
 <li>Package annotations referenced through JAR dependencies are now correctly reflected in the PSI model. [<a href="https://youtrack.jetbrains.com/issue/IDEA-383732">IDEA-383732</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/02/intellij-idea-2025-3-3/">blog post</a>.</p>
    