### PR TITLE
Upgrading IntelliJ from 2025.3.4 to 2026.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.3.4 to 2026.1
 - Upgrading IntelliJ from 2025.3.3 to 2025.3.4
 
 ### Deprecated

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/rust-analyzer-lsp-intellij-
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 0.2.5
+pluginVersion = 1.0.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 253
-pluginUntilBuild = 253.*
+pluginSinceBuild = 261
+pluginUntilBuild = 261.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.3.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -31,7 +31,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.3.4
+platformVersion = 2026.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.3.4 to 2026.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662652

# What's New?
<p>IntelliJ IDEA 2026.1 is now out! The highlights of this release include:</p>
<p><strong>Any agent, built-in:</strong></p>
<ul>
 <li>ACP Registry: Browse and install AI agents in one click.</li>
 <li>Git worktrees: Work in parallel branches and hand one off to an agent while you keep moving in another.</li>
 <li>Database access for AI agents: Let Codex or Claude Agent query and modify your data sources natively.</li>
</ul>
<p><strong>Intelligence in the platform:</strong></p>
<ul>
 <li>Quota-free next edit suggestions: Propagate changes throughout a given file with IDE-driven assistance.</li>
 <li>Spring runtime insight: Inspect injected beans, endpoint security, and property values without pausing execution.</li>
 <li>Kotlin-aware JPA: Detect and fix Kotlin-specific pitfalls in Jakarta Persistence entities.</li>
</ul>
<p><strong>First-class language support:</strong></p>
<ul>
 <li>Java 26: Enjoy day-one support, including preview features.</li>
 <li>Kotlin 2.3.20: Enjoy day-one support, including experimental features.</li>
 <li>C/C++ in IntelliJ IDEA: Access first-class C/C++ coding assistance for multi-language projects.</li>
 <li>Support for JavaScript without an Ultimate subscription.</li>
</ul>
<p><strong>Productivity and environment:</strong></p>
<ul>
 <li>Expanded command completion, now with AI actions, postfix templates, and config file support.</li>
 <li>Better performance for large-scale TypeScript projects.</li>
 <li>Native Dev Container workflow: Open containerized projects as if they were local.</li>
</ul>
<p><br>
 Visit our <a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about these and other improvements.</p>
    