### PR TITLE
Upgrading IntelliJ from 2026.2 to 2026.2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [1.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.2 to 2026.2.0.1
 - Upgrading IntelliJ from 2026.1.4 to 2026.2
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/rust-analyzer-lsp-intellij-
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.1.0
+pluginVersion = 1.1.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.2.0.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels = DEPRECATED_API_USAGES
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -31,7 +31,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.2
+platformVersion = 2026.2.0.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.2 to 2026.2.0.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662711

# What's New?
<p>IntelliJ IDEA 2026.2.0.1 is out with the following hotfix:</p>
<p>Resolved issues affecting projects containing files stored in cloud-synced folders on Windows <a href="https://youtrack.jetbrains.com/issue/IJPL-250709">[IJPL-250709]</a>, preventing repeated project reloads, endless re-imports, and files from disappearing or closing unexpectedly. <a href="https://youtrack.jetbrains.com/issue/IDEA-391665">[IDEA-391665]</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-250598">[IJPL-250598]</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-250615">[IJPL-250615]</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-250539">[IJPL-250539]</a>.</p>
<p>For more details, please refer to the <a href="https://youtrack.jetbrains.com/articles/IDEA-A-2100662711/IntelliJ-IDEA-2026.2.0.1-262.8665.337-build-Release-Notes">release notes</a></p>
    